### PR TITLE
Add ids to documentation sections

### DIFF
--- a/app/views/page/documentation.html.erb
+++ b/app/views/page/documentation.html.erb
@@ -11,7 +11,7 @@
 </div>
 
 <div class="span-11">
-  <h2 class="section-start">Tutorials</h2>
+  <h2 class="section-start" id="tutorials">Tutorials</h2>
   
   <h3 class="title">Short and Sweet</h3>
 
@@ -59,7 +59,7 @@
     &#8211; Guides on a variety of Git and GitHub related topics
   </p>
 
-  <h2 class="section-start">Reference</h2>
+  <h2 class="section-start" id="reference">Reference</h2>
   <p>
     The official and comprehensive
     <a href="http://www.kernel.org/pub/software/scm/git/docs/">reference manual</a>
@@ -77,7 +77,7 @@
 </div>
 
 <div class="span-10 last">
-  <h2 class="section-start">Books</h2>
+  <h2 class="section-start" id="books">Books</h2>
 
   <table>
     <tr><td>
@@ -132,7 +132,7 @@
 </div>
 
 <div class="span-21 videos">
-	<h2 class="section-start">Videos</h2>
+	<h2 class="section-start" id="videos">Videos</h2>
 	
 	<table width="100%" class="videos">
 	  <tr>
@@ -176,7 +176,7 @@
 
 <div class="span-21">
 
-  <h2 class="section-start">Commands</h2>
+  <h2 class="section-start" id="commands">Commands</h2>
 
   <p>Here is a list of the most common commands you're likely to use on a day-to-day basis.</p>
   


### PR DESCRIPTION
Hi Scott,

First off, I appreciate all the hard work you have done wrt git.  Your material has been very helpful!

I would like to link directly to a specific section within a page so I've started adding ids to the sections.  I've started with the documentation section.  This allows for something like http://git-scm.com/documentation#commands.

Let me know what you think.

Rob
