### PR TITLE
Fix http cloning info

### DIFF
--- a/app/views/page/download.html.erb
+++ b/app/views/page/download.html.erb
@@ -83,8 +83,7 @@
   <p>If you have problems connecting (Git uses port 9418),
   you can try to access the repository over the HTTP protocol:</p>
   <pre><strong>git clone http://git.kernel.org/pub/scm/git/git.git</strong></pre>
-  <p>(this method is considerably slower but works even behind
-  firewalls and such).</p>
+  <p>(this method works even behind firewalls and such).</p>
 
   <p>You can also always browse the current contents
   of the git repository using either

--- a/app/views/page/download.html.erb
+++ b/app/views/page/download.html.erb
@@ -82,7 +82,7 @@
 
   <p>If you have problems connecting (Git uses port 9418),
   you can try to access the repository over the HTTP protocol:</p>
-  <pre><strong>git clone http://www.kernel.org/pub/scm/git/git.git</strong></pre>
+  <pre><strong>git clone http://git.kernel.org/pub/scm/git/git.git</strong></pre>
   <p>(this method is considerably slower but works even behind
   firewalls and such).</p>
 


### PR DESCRIPTION
Download link and information about http transport are somewhat out of date.
