### PR TITLE
Only store stable release versions

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -28,7 +28,7 @@ class Version
     commits = get("/repos/gitster/git/commits", :query => {:sha => maint_sha}).parsed_response
     commits.each do |commit|
       message = commit['commit']['message'].split("\n").first
-      if m = /^Git (.*?)$/.match(message)
+      if m = /^Git ([0-9.]+)$/.match(message)
         version = m[1]
         p commit['sha']
         if !Version.first(:version => version)


### PR DESCRIPTION
The current website shows 1.7.7-rc3 as the latest stable version, this commit fixes that. You might need to wipe the current database (or just the 1.7.7-rc3 version) so it disappears from the current site.
