### PR TITLE
Advertise git-cola

### DIFF
--- a/views/tools.erb
+++ b/views/tools.erb
@@ -45,6 +45,10 @@ for a full list.</p>
   GUI for browsing history of Git repositories, similar to <em>gitk</em>
   but with more features.</dd>
 
+  <dt id="git-cola">git-cola (PyQt)</dt>
+  <dd><a href="http://git-cola.github.com/">git-cola</a> is a powerful
+  git GUI with a slick and intuitive user interface.</dd>
+
   <dt id="tig">Tig</dt>
   <dd><a href="http://jonas.nitro.dk/tig/">tig</a>
   is a text-mode interface for Git. It acts as a repository browser


### PR DESCRIPTION
git-cola has more active users than qgit according to
Debian's popcon.  Link to its github homepage.

Reference: http://popcon.debian.org/by_vote

```
<name> is the package name;
<inst> is the number of people who installed this package;
<vote> is the number of people who use this package regularly;
<old> is the number of people who installed, but don't use this package
      regularly;
<recent> is the number of people who upgraded this package recently;

rank  name                            inst  vote   old recent

5798  tig                              861   194   529   138
6124  git-cola                         458   173   231    54
6616  qgit                             906   147   705    54
```
