### PR TITLE
Fix the link the the InterfacesFrontendsAndTools wiki page

### DIFF
--- a/views/tools.erb
+++ b/views/tools.erb
@@ -14,7 +14,7 @@ are several alternative porcelains which might offer considerably more
 user friendly interface or extend Git to perform some specialized tasks.</p>
 
 <p>Below, the most widely used tools are listed. Please refer to
-<a href="http://git.wiki.kernel.org/index.php/InterfacesFrontendsAndTools">the corresponding wiki page</a>
+<a href="https://git.wiki.kernel.org/articles/i/n/t/Interfaces,_frontends,_and_tools.html">the corresponding wiki page</a>
 for a full list.</p>
 
 <table class="data-table software">


### PR DESCRIPTION
http://git.wiki.kernel.org/index.php/InterfacesFrontendsAndTools does not seem to exist anymore; 
https://git.wiki.kernel.org/articles/i/n/t/Interfaces,_frontends,_and_tools.html seems to have the content we're looking for
