### PR TITLE
Correct outdated kernel.org wiki links, add more git hosting links, add gitslave advertising

### DIFF
--- a/views/tools.erb
+++ b/views/tools.erb
@@ -80,6 +80,15 @@ for a full list.</p>
   TopGit achieves that by keeping a separate topic branch 
   for each patch and providing few tools to maintain the branches.</dd>
 
+  <dt id="gitslave">Gitslave</dt>
+  <dd><a href="http://gitslave.sf.net">Gitslave</a>
+   is useful to add subsidiary git repositories to a git
+   superproject when you control and develop on the subprojects at
+   more of less the same time as the superproject, and furthermore
+   when you typically want to tag, branch, push, pull, etc all
+   repositories at the same time.  It is an alternative to
+   git-submodule and the git subtree merge strategy.
+
 </dl>
 </td>
 </tr>

--- a/views/tools.erb
+++ b/views/tools.erb
@@ -14,7 +14,7 @@ are several alternative porcelains which might offer considerably more
 user friendly interface or extend Git to perform some specialized tasks.</p>
 
 <p>Below, the most widely used tools are listed. Please refer to
-<a href="http://git.wiki.kernel.org/index.php/InterfacesFrontendsAndTools">the corresponding wiki page</a>
+<a href="https://git.wiki.kernel.org/articles/i/n/t/Interfaces,_frontends,_and_tools.html">the corresponding wiki page</a>
 for a full list.</p>
 
 <table class="data-table software">
@@ -159,4 +159,4 @@ local installations and with open source code.</dd>
 </tr>
 </table>
 
-<p style="text-align: right; font-size: small"><a href="http://git.wiki.kernel.org/index.php/GitHosting">more sites</a></p>
+<p style="text-align: right; font-size: small"><a href="http://en.wikipedia.org/wiki/Comparison_of_open_source_software_hosting_facilities">more</a> and<a href="https://git.wiki.kernel.org/articles/g/i/t/GitHosting_2036.html">more sites</a></p>


### PR DESCRIPTION
The first patch should be trivially acceptable.  It corrects some bad links on the page and adds a supplementary link.  The second patch adds gitslave (http://gitslave.sf.net) to the list of version control interface layer tools.  The other tools are all "patch management interface layer" tools, but unlike in the  git wiki, that isn't the title of this section.  According to the latest git survey (very scientific) gitslave users are 10% of git-submodule users.
