### PR TITLE
Included Assembla in hosting list, fixed 'more sites' link

### DIFF
--- a/views/tools.erb
+++ b/views/tools.erb
@@ -118,6 +118,15 @@ local installations and with open source code.</dd>
   <h3>Public and Private Hosting</h3>
 
 <dl>
+  <dt id="assembla">Assembla</dt>
+  <dd><a href="http://www.assembla.com/">Assembla</a> offers secure and reliable 
+  Git hosting with features such as a web-based code browser, inline code commenting, 
+  support for git over http, easy-to-use merge request workflows, and deployment tools. 
+  Free private Git hosting provides unlimited users with 1GB. Public repositories 
+  are free and include bug/issue tracking and collaboration tools.</dd>
+</dl>
+
+<dl>
   <dt id="github">GitHub</dt>
   <dd><a href="http://github.com/">GitHub</a> is the largest hosting site
   with over 1,000,000 public repositories and 
@@ -159,4 +168,4 @@ local installations and with open source code.</dd>
 </tr>
 </table>
 
-<p style="text-align: right; font-size: small"><a href="http://git.wiki.kernel.org/index.php/GitHosting">more sites</a></p>
+<p style="text-align: right; font-size: small"><a href="https://git.wiki.kernel.org/articles/g/i/t/GitHosting_2036.html">more sites</a></p>


### PR DESCRIPTION
Hi Scott, Adam from Assembla (adam@assembla.com) had previously contacted you regarding the addition of Assembla onto your git-scm.com/tools page. This pull request is the implementation of the requested addition, along with a quick fix to the "more sites" link on the bottom of that page. Hope it helps!
