### PR TITLE
Update stale URLs to wiki.kernel.org

### DIFF
--- a/views/sfc.erb
+++ b/views/sfc.erb
@@ -8,7 +8,7 @@ provides financial and administrative assistance to open source projects.
 
 <p>The SFC accepts donations on git's behalf. In the past, project money has
 typically gone to defraying travel costs for developers to come to our annual
-<a href="https://git.wiki.kernel.org/index.php/GitTogether">GitTogether</a>
+<a href="https://git.wiki.kernel.org/articles/g/i/t/GitTogether_3474.html">GitTogether</a>
 mini-conference.  A portion of the money goes to the SFC to cover their
 operating expenses. You can also donate <a
 href="http://sfconservancy.org/donate">directly</a> to the Conservancy's

--- a/views/tools.erb
+++ b/views/tools.erb
@@ -14,7 +14,7 @@ are several alternative porcelains which might offer considerably more
 user friendly interface or extend Git to perform some specialized tasks.</p>
 
 <p>Below, the most widely used tools are listed. Please refer to
-<a href="http://git.wiki.kernel.org/index.php/InterfacesFrontendsAndTools">the corresponding wiki page</a>
+<a href="https://git.wiki.kernel.org/articles/i/n/t/Interfaces,_frontends,_and_tools.html">the corresponding wiki page</a>
 for a full list.</p>
 
 <table class="data-table software">
@@ -159,4 +159,4 @@ local installations and with open source code.</dd>
 </tr>
 </table>
 
-<p style="text-align: right; font-size: small"><a href="http://git.wiki.kernel.org/index.php/GitHosting">more sites</a></p>
+<p style="text-align: right; font-size: small"><a href="https://git.wiki.kernel.org/articles/g/i/t/GitHosting_2036.html">more sites</a></p>


### PR DESCRIPTION
This should fix all the surviving references to k.org pages (these are hits from "git grep git.wiki.kernel.org", excluding the ones that are commented out).

I actually was wondering where the credit page that lists people who wrote Git is, so that I can answer "Who wrote Git" by pointing at it, instead of telling them to clone git.git and run shortlog -s -n, but the removal of that page predates the history in this repository, it seems.
