### PR TITLE
Correctly identify latest stable git version

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -6,7 +6,7 @@ require './lib/version'
 class GitApp < Sinatra::Base
 
   def get_version
-    if v = Version.first(:order => [:created_at.desc])
+    if v = Version.last(:order => [:version])
       @version = v.version
       @date = v.created_at.strftime("%Y-%m-%d")
     end


### PR DESCRIPTION
Maintenance releases for version n-1 and n-2 can have later dates than
the latest stable n, so they're not a good way to determine the latest
release. The latest release should be calculated using the version
number alone.

git-scm.com now shows 1.7.6.6 as the latest stable even though it's 1.7.9.
