### PR TITLE
deprecation notice at top of readme for gitscm-next

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## This repo is deprecated and no longer being maintained, look over at [gitscm-next](https://github.com/github/gitscm-next) for continued development.
+
 ## The Git Website ##
 
 This is the source for the main Git website, found at git-scm.com.


### PR DESCRIPTION
readme should really direct people over to gitscm-next for additional works etc.
